### PR TITLE
[gui] Fix error when exiting on MacOS

### DIFF
--- a/ltchiptool/gui/panels/log.py
+++ b/ltchiptool/gui/panels/log.py
@@ -183,6 +183,8 @@ class LogPanel(BasePanel):
 
     def OnShow(self):
         super().OnShow()
+        if self.delayed_lines is None:
+            return
         for log_prefix, message, color in self.delayed_lines:
             self.emit_raw(log_prefix, message, color)
         self.delayed_lines = None


### PR DESCRIPTION
For some reason on MacOS the OnShow method of the
LogPanel is called when exiting the application. This causes the panel to try to print the delayed_lines again and throw an error.

A check whether delayed_lines is None has been added.

Screenshot of the error:

<img width="892" alt="image" src="https://user-images.githubusercontent.com/5400940/236651306-3bb2af18-2ed1-49d6-bb8d-8b3006530296.png">

Btw here is the full traceback of the second call to OnShow:

```
 File "<string>", line 1, in <module>
  File "/Users/alufers/Projects/Contrib/ltchiptool/ltchiptool/__init__.py", line 23, in cli
    cli()
  File "/Users/alufers/Projects/Contrib/ltchiptool/ltchiptool/__main__.py", line 97, in cli
    cli_entrypoint()
  File "/Users/alufers/Library/Caches/pypoetry/virtualenvs/ltchiptool-XyYUebX7-py3.10/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/alufers/Library/Caches/pypoetry/virtualenvs/ltchiptool-XyYUebX7-py3.10/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/alufers/Library/Caches/pypoetry/virtualenvs/ltchiptool-XyYUebX7-py3.10/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/alufers/Library/Caches/pypoetry/virtualenvs/ltchiptool-XyYUebX7-py3.10/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/alufers/Library/Caches/pypoetry/virtualenvs/ltchiptool-XyYUebX7-py3.10/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/alufers/Projects/Contrib/ltchiptool/ltchiptool/util/../../ltchiptool/gui/__main__.py", line 47, in cli
    gui_entrypoint(*args, **kwargs)
  File "/Users/alufers/Projects/Contrib/ltchiptool/ltchiptool/util/../../ltchiptool/gui/__main__.py", line 30, in gui_entrypoint
    app.MainLoop()
  File "/Users/alufers/Library/Caches/pypoetry/virtualenvs/ltchiptool-XyYUebX7-py3.10/lib/python3.10/site-packages/wx/core.py", line 2262, in MainLoop
    rv = wx.PyApp.MainLoop(self)
  File "/Users/alufers/Projects/Contrib/ltchiptool/ltchiptool/gui/main.py", line 167, in OnClose
    self.Destroy()
  File "/Users/alufers/Projects/Contrib/ltchiptool/ltchiptool/gui/main.py", line 152, in OnShow
    panel.OnShow()
  File "/Users/alufers/Projects/Contrib/ltchiptool/ltchiptool/gui/panels/log.py", line 187, in OnShow
    traceback.print_stack()
    ```
    
    I have no idea why self.Destroy() calls OnShow, but it does...
