### PR TITLE
[ln882h] Reduce transfer baudrate to improve reliability

### DIFF
--- a/ltchiptool/soc/ln882h/util/ln882htool.py
+++ b/ltchiptool/soc/ln882h/util/ln882htool.py
@@ -14,7 +14,7 @@ from ltchiptool.util.serialtool import SerialToolBase
 
 _T_YmodemCB = Optional[Callable[[int, str, int, int], None]]
 
-LN882H_YM_BAUDRATE = 2000000
+LN882H_YM_BAUDRATE = 1000000
 LN882H_ROM_BAUDRATE = 115200
 LN882H_FLASH_ADDRESS = 0x0000000
 LN882H_RAM_ADDRESS = 0x20000000


### PR DESCRIPTION
LN882H : Changed file transfer baudrate from 2Mbit to 1Mbit.

Transfers at 2Mbit fail too often.