### PR TITLE
[ln882h] Fix flash write temp file access on Windows

### DIFF
--- a/ltchiptool/soc/ln882h/util/ln882htool.py
+++ b/ltchiptool/soc/ln882h/util/ln882htool.py
@@ -207,18 +207,17 @@ class LN882hTool(SerialToolBase):
         self.command(f"startaddr 0x{offset:X}")
 
         # Convert stream to temporary file before sending with YMODEM
-        tmp_file = NamedTemporaryFile()
-        with open(tmp_file.name, "wb") as f:
+        with NamedTemporaryFile(delete=False) as f:
             f.write(stream.getbuffer())
 
-            self.command(f"upgrade", waitresp=False)
+        self.command(f"upgrade", waitresp=False)
 
-            self.push_timeout(3)
-            debug(f"YMODEM: transmitting to 0x{offset:X}")
-            if not self.ym.send([f.name], callback=callback):
-                self.change_baudrate(prev_baudrate)
-                self.pop_timeout()
-                raise RuntimeError("YMODEM transmission failed")
+        self.push_timeout(3)
+        debug(f"YMODEM: transmitting to 0x{offset:X}")
+        if not self.ym.send([f.name], callback=callback):
+           self.change_baudrate(prev_baudrate)
+           self.pop_timeout()
+           raise RuntimeError("YMODEM transmission failed")
 
         self.link()
 

--- a/ltchiptool/soc/ln882h/util/ln882htool.py
+++ b/ltchiptool/soc/ln882h/util/ln882htool.py
@@ -215,9 +215,9 @@ class LN882hTool(SerialToolBase):
         self.push_timeout(3)
         debug(f"YMODEM: transmitting to 0x{offset:X}")
         if not self.ym.send([f.name], callback=callback):
-           self.change_baudrate(prev_baudrate)
-           self.pop_timeout()
-           raise RuntimeError("YMODEM transmission failed")
+            self.change_baudrate(prev_baudrate)
+            self.pop_timeout()
+            raise RuntimeError("YMODEM transmission failed")
 
         self.link()
 

--- a/ltchiptool/soc/ln882h/util/ln882htool.py
+++ b/ltchiptool/soc/ln882h/util/ln882htool.py
@@ -14,7 +14,7 @@ from ltchiptool.util.serialtool import SerialToolBase
 
 _T_YmodemCB = Optional[Callable[[int, str, int, int], None]]
 
-LN882H_YM_BAUDRATE = 2000000
+LN882H_YM_BAUDRATE = 1000000
 LN882H_ROM_BAUDRATE = 115200
 LN882H_FLASH_ADDRESS = 0x0000000
 LN882H_RAM_ADDRESS = 0x20000000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ltchiptool"
-version = "4.11.6"
+version = "4.12.0"
 description = "Universal flashing and binary manipulation tool for IoT chips"
 authors = ["Kuba Szczodrzyński <kuba@szczodrzynski.pl>"]
 license = "MIT"


### PR DESCRIPTION
LN882H Flash write: fix temporary file access permissions on Windows platform (issue #67)
